### PR TITLE
Adapt FFI module

### DIFF
--- a/examples/ffi_c/README.md
+++ b/examples/ffi_c/README.md
@@ -1,6 +1,6 @@
 # FFI C Example: E2E — TFHE public-key encryption, AES-CTR, and ZKP proof
 
-This example demonstrates how to use the generated C bindings to call the TFHE public-key encryption from C and how to generate a ZK proof.
+This example demonstrates how to use the generated C bindings to call the TFHE public‑key encryption from C and how to generate a ZK proof.
 
 ## Build & Run example
 
@@ -21,7 +21,9 @@ This example demonstrates how to use the generated C bindings to call the TFHE p
 - Creates dummy public key arrays `(pk_a, pk_b)`; replace with a real key in practice.
 - Calls `tfhe_pk_encrypt_aes_key` to encode a dummy 16‑byte AES‑128 key into the plaintext polynomial and encrypt it with the TFHE public key.
 - Calls `aes_ctr_encrypt` to encrypt 64 bytes with that AES key and prints the first 16 bytes of ciphertext.
-- Calls `zkp_generate_proof` to produce a STARK proof from a caller-provided leaf, Merkle neighbors, side flags, and nonce. Demo inputs are small, fixed arrays.
+- Calls `zkp_generate_proof` to produce a STARK proof from a caller‑provided leaf, Merkle neighbors, side flags, and nonce. Demo inputs are small, fixed arrays.
+  The function returns an opaque postcard bundle containing `(proof, public_values)` where `public_values`
+  is exactly 24 field elements in this layout: `[root(8) | nonce_field_rep(8) | hash(nonce||leaf)(8)]`.
 
 ## Notes
 
@@ -29,9 +31,10 @@ This example demonstrates how to use the generated C bindings to call the TFHE p
 - API returns status codes: `BATTERY_OK`, `BATTERY_ERR_NULL`, `BATTERY_ERR_BADLEN`, `BATTERY_ERR_SEEDLEN`, `BATTERY_ERR_INPUT`, `BATTERY_ERR_BUFSZ`.
 - All inputs/outputs use opaque byte buffers; no special alignment requirements.
 - For `zkp_generate_proof`:
-  - Hash width is `HASH_SIZE = 8` field elements. The Merkle depth is the `levels` argument (32 in the example `LEVELS = 32`).
+  - Hash width is `HASH_SIZE = 8` field elements. After commit 8bca163, the STARK trace starts with an extra first row hashing `(nonce || leaf)`, so the number of rows is `levels + 1`.
+    The prover stack requires the trace height to be a power of two, so callers must choose `levels = 2^k - 1` (e.g., 31 -> rows 32).
   - `leaf8_u32` has 8 field elements as `uint32_t` (must be canonical for the KoalaBear field).
   - `neighbors8_by_level_u32` has `levels * 8` field elements in row-major order; level `l` occupies indices `[l*8 .. l*8+8)`.
   - `sides_bitflags[lvl]` indicates neighbor position: `0` = neighbor on the right (concat `[current || neighbor]`), `1` = neighbor on the left (concat `[neighbor || current]`). Only `0` or `1` are accepted; additionally, `sides[0]` MUST be `0` to enforce proof uniqueness.
-  - `nonce32` is a 32‑byte seed used in Fiat–Shamir; different nonces produce different proofs for the same inputs.
+  - `nonce32` is a 32‑byte seed used in Fiat–Shamir; different nonces produce different proofs for the same inputs. The Merkle root in `public_values[0..8]` is independent of the nonce; however, `public_values[16..24] = hash(nonce||leaf)` changes per nonce and can be used as a per‑session device identity.
   - Caller must provide output buffers (`proof_out`, `ct_out`) large enough for postcard‑serialized outputs; if too small, the functions return `BATTERY_ERR_BUFSZ`.

--- a/examples/ffi_c/e2e.c
+++ b/examples/ffi_c/e2e.c
@@ -89,6 +89,7 @@ int main(int argc, char** argv) {
         memsnap_t base; read_memsnap(&base);
         unsigned char proof_buf[1<<19]; // 0.5 MiB demo buffer
         size_t proof_written = 0;
+        // zkp_generate_proof returns a postcard-serialized bundle: (proof, public_values)
         rc = zkp_generate_proof(args_buf,
                                 args_len,
                                 zkp_nonce,

--- a/examples/ffi_c/e2e.c
+++ b/examples/ffi_c/e2e.c
@@ -54,7 +54,9 @@ int main(int argc, char** argv) {
     const char* mode = (argc > 1) ? argv[1] : "both"; // modes: "zkp", "tfhe", "both"
     // ZKP: generate public values (e.g., Merkle root)  and zk proof for a provided leaf & path
     // Use a compile-time constant to avoid VLA warnings
-    enum { LEVELS = 32 }; // demo depth
+    // The ZKP trace adds an initial row for hash(nonce||leaf),
+    // so `levels + 1` must be a power of two. For a depth-32 demo, pass 31 here.
+    enum { LEVELS = 31 }; // demo depth -> rows = 32
     uint32_t leaf8_u32[8];
     uint32_t neighbors8_by_level_u32[LEVELS * 8];
     uint8_t sides[LEVELS];

--- a/include/battery.h
+++ b/include/battery.h
@@ -70,7 +70,8 @@ int32_t tfhe_pk_encrypt_aes_key(const uint8_t *pk,
  * - `args`/`args_len`: postcard-serialized OpaqueMerklePathArgs
  * - `nonce32` (len=`BATTERY_NONCE_LEN`)
  * Outputs:
- * - `proof_out`/`proof_out_len`: caller-provided buffer for postcard-serialized proof.
+ * - `proof_out`/`proof_out_len`: caller-provided buffer for postcard-serialized bundle:
+ *   (proof, public_values) where public_values = [root(8) | nonce_field(8) | hash(nonce||leaf)(8)].
  * - `out_proof_written`: number of bytes written. If too small, returns `BATTERY_ERR_BUFSZ`.
  *
  * Serialization: postcard 1.x (stable).

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,6 +3,7 @@ use crate::aes_ctr::aes_ctr_encrypt_in_place;
 use crate::tfhe::encode_bits_as_trlwe_plaintext;
 use crate::tfhe::{TFHEPublicKey, TRLWECiphertext};
 use crate::zkp::{self, Val};
+use p3_uni_stark::Proof;
 
 use p3_field::integers::QuotientMap;
 use rand::SeedableRng;
@@ -108,6 +109,12 @@ pub extern "C" fn tfhe_pk_encrypt_aes_key(
 // ------------- ZKP -------------
 
 #[derive(serde::Serialize, serde::Deserialize)]
+struct ZkpProofBundle(
+    Proof<zkp::MerkleInclusionConfig>,
+    Vec<Val>, // public values layout: [root(8) | nonce_field(8) | hash(nonce||leaf)(8)]
+);
+
+#[derive(serde::Serialize, serde::Deserialize)]
 struct OpaqueMerklePathArgs {
     leaf8_u32: [u32; 8],
     neighbors8_by_level_u32: Vec<[u32; 8]>,
@@ -119,7 +126,8 @@ struct OpaqueMerklePathArgs {
 /// - `args`/`args_len`: postcard-serialized OpaqueMerklePathArgs
 /// - `nonce32` (len=`BATTERY_NONCE_LEN`)
 /// Outputs:
-/// - `proof_out`/`proof_out_len`: caller-provided buffer for postcard-serialized proof.
+/// - `proof_out`/`proof_out_len`: caller-provided buffer for postcard-serialized bundle:
+///   (proof, public_values) where public_values = [root(8) | nonce_field(8) | hash(nonce||leaf)(8)].
 /// - `out_proof_written`: number of bytes written. If too small, returns `BATTERY_ERR_BUFSZ`.
 ///
 /// Serialization: postcard 1.x (stable).
@@ -180,13 +188,14 @@ pub extern "C" fn zkp_generate_proof(
         return BATTERY_ERR_INPUT;
     }
     let (proof, public_values) = zkp::generate_proof(&leaf, &neighbors, &nonce_arr);
-    // Public values now include: root (8), nonce field rep (8), and hash(nonce||leaf) (8).
-    // Only the first 8 are constrained by the AIR here, so just sanity-check the minimum.
-    if public_values.len() < zkp::HASH_SIZE {
+    // Public values layout is fixed at 24 = 3 * HASH_SIZE elements:
+    //   [root(8) | nonce_field(8) | hash(nonce||leaf)(8)].
+    if public_values.len() != 3 * zkp::HASH_SIZE {
         return BATTERY_ERR_INPUT;
     }
+    let bundle = ZkpProofBundle(proof, public_values);
     let out_bytes = unsafe { core::slice::from_raw_parts_mut(proof_out, proof_out_len) };
-    match postcard::to_slice(&proof, out_bytes) {
+    match postcard::to_slice(&bundle, out_bytes) {
         Ok(rem) => {
             let written = proof_out_len - rem.len();
             unsafe {
@@ -194,7 +203,7 @@ pub extern "C" fn zkp_generate_proof(
             }
             BATTERY_OK
         }
-        Err(_) => match postcard::to_allocvec(&proof) {
+        Err(_) => match postcard::to_allocvec(&bundle) {
             Ok(bytes) => {
                 unsafe {
                     *out_proof_written = bytes.len();
@@ -340,7 +349,6 @@ pub extern "C" fn zkp_pack_args(
 #[cfg(all(test, feature = "ffi"))]
 mod tests {
     use super::*;
-    use postcard::from_bytes;
 
     #[test]
     fn pack_public_key_roundtrip() {
@@ -356,7 +364,7 @@ mod tests {
             &mut written as *mut usize,
         );
         assert_eq!(rc, BATTERY_OK);
-        let pk: TFHEPublicKey<TFHE_TRLWE_N, Q> = from_bytes(&buf[..written]).unwrap();
+        let pk: TFHEPublicKey<TFHE_TRLWE_N, Q> = postcard::from_bytes(&buf[..written]).unwrap();
         for i in 0..TFHE_TRLWE_N {
             assert_eq!(pk.ct.a.coeffs[i], 1u64 % Q);
             assert_eq!(pk.ct.b.coeffs[i], 2u64 % Q);
@@ -425,5 +433,49 @@ mod tests {
         );
         assert_eq!(rc2, BATTERY_ERR_BUFSZ);
         assert!(proof_written > 0);
+    }
+
+    #[test]
+    fn zkp_proof_bundle_roundtrip() {
+        // Build opaque args for a valid path (rows = levels + 1 = 32)
+        let levels = 31usize;
+        let leaf = [4u32; 8];
+        let neighbors = vec![3u32; levels * 8];
+        let sides = vec![0u8; levels];
+        let mut args_buf = vec![0u8; 1 << 16];
+        let mut args_len: usize = 0;
+        let rc = zkp_pack_args(
+            leaf.as_ptr(),
+            neighbors.as_ptr(),
+            sides.as_ptr(),
+            levels,
+            args_buf.as_mut_ptr(),
+            args_buf.len(),
+            &mut args_len as *mut usize,
+        );
+        assert_eq!(rc, BATTERY_OK);
+
+        // Generate the bundle and deserialize it
+        let nonce = [0x11u8; BATTERY_NONCE_LEN];
+        let mut out = vec![0u8; 1 << 20];
+        let mut written = 0usize;
+        let rc2 = zkp_generate_proof(
+            args_buf.as_ptr(),
+            args_len,
+            nonce.as_ptr(),
+            out.as_mut_ptr(),
+            out.len(),
+            &mut written as *mut usize,
+        );
+        assert_eq!(rc2, BATTERY_OK);
+        assert!(written > 0);
+
+        let bundle: ZkpProofBundle = postcard::from_bytes(&out[..written]).unwrap();
+        // Expect exactly 3 * HASH_SIZE public values: root(8) | nonce_field(8) | hash(nonce||leaf)(8)
+        assert_eq!(bundle.1.len(), 3 * zkp::HASH_SIZE);
+        // Re-serialize and deserialize again to check roundtrip stability of the bundle
+        let bytes2 = postcard::to_allocvec(&bundle).unwrap();
+        let bundle2: ZkpProofBundle = postcard::from_bytes(&bytes2).unwrap();
+        assert_eq!(bundle2.1, bundle.1);
     }
 }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -5,11 +5,7 @@ use rand::Rng;
 // Const-generic helpers over fixed modulus Q
 #[inline(always)]
 const fn qmask<const Q: u64>() -> u64 {
-    if Q.is_power_of_two() {
-        Q - 1
-    } else {
-        0
-    }
+    if Q.is_power_of_two() { Q - 1 } else { 0 }
 }
 
 #[inline(always)]

--- a/src/zkp/air.rs
+++ b/src/zkp/air.rs
@@ -202,16 +202,15 @@ impl<
         }
         eval_poseidon2(self, builder, hash.borrow());
         let public_values = builder.public_values().to_vec();
-        /*
         for i in 0..HASH_SIZE {
             builder
                 .when_first_row()
                 .assert_eq(inputs[i], public_values[HASH_SIZE + i]);
-            builder
-                .when_first_row()
-                .assert_eq(hash[hash.len() - WIDTH + i], public_values[2 * HASH_SIZE + i]);
+            builder.when_first_row().assert_eq(
+                hash[hash.len() - WIDTH + i],
+                public_values[2 * HASH_SIZE + i],
+            );
         }
-        */
         // Bind last-row output to PV[0..HASH_SIZE] = Merkle root.
         for i in 0..HASH_SIZE {
             builder

--- a/src/zkp/air.rs
+++ b/src/zkp/air.rs
@@ -202,6 +202,17 @@ impl<
         }
         eval_poseidon2(self, builder, hash.borrow());
         let public_values = builder.public_values().to_vec();
+        /*
+        for i in 0..HASH_SIZE {
+            builder
+                .when_first_row()
+                .assert_eq(inputs[i], public_values[HASH_SIZE + i]);
+            builder
+                .when_first_row()
+                .assert_eq(hash[hash.len() - WIDTH + i], public_values[2 * HASH_SIZE + i]);
+        }
+        */
+        // Bind last-row output to PV[0..HASH_SIZE] = Merkle root.
         for i in 0..HASH_SIZE {
             builder
                 .when_last_row()

--- a/src/zkp/mod.rs
+++ b/src/zkp/mod.rs
@@ -176,9 +176,8 @@ pub fn verify_proof(
 mod test {
     use p3_field::integers::QuotientMap;
 
-    use crate::zkp::{nonce_field_rep, verify_proof};
+    use crate::zkp::{MerkleInclusionConfig, Val, generate_proof, nonce_field_rep, verify_proof};
 
-    use super::{MerkleInclusionConfig, Val, generate_proof, verify_proof};
     use p3_uni_stark::Proof;
 
     #[test]
@@ -216,6 +215,7 @@ mod test {
         verify_proof(&nonce, &proof, &public_values).unwrap();
     }
 
+    #[test]
     fn verifier_should_reject_inconsistent_nonce_public_values() {
         use super::*;
 


### PR DESCRIPTION
Adapt FFI module to take into consideration recent changes to the zkp module (hash(nonce || leaf) as public output)

Fixed forgery issues with zkp proving/verification.