### PR TITLE
Final api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ strip = true
 incremental = false
 panic = "abort"
 
+[profile.dev]
+# no_std builds require aborting panics; match release profile
+panic = "abort"
+
 [dependencies]
 rand_chacha = { version = "0.9", default-features = false }
 rand = { version = "0.9", default-features = false }

--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -21,9 +21,10 @@ This example demonstrates how to use the generated C bindings to call the TFHE p
 - Creates dummy public key arrays `(pk_a, pk_b)`; replace with a real key in practice.
 - Calls `tfhe_pk_encrypt` to encode arbitrary bytes (here: a 16‑byte AES‑128 key) into the plaintext polynomial and encrypt it with the TFHE public key.
 - Calls `aes_ctr_encrypt` to encrypt 64 bytes with that AES key and prints the first 16 bytes of ciphertext.
-- Calls `zkp_generate_proof` to produce a STARK proof from a caller‑provided leaf, Merkle neighbors, side flags, and nonce. Demo inputs are small, fixed arrays.
-  The function returns an opaque postcard bundle containing `(proof, public_values)` where `public_values`
-  is exactly 24 field elements in this layout: `[root(8) | nonce_field_rep(8) | hash(leaf||nonce)(8)]`.
+- Calls `zkp_generate_proof` to produce a STARK proof. The device passes both secret leaves (`secret16_u32 = [leaf(8) | sibling(8)]`),
+  and the server supplies an opaque postcard for the parent→root path (`zkp_pack_args`). The function returns an opaque postcard bundle
+  containing `(proof, public_values)` where `public_values` is exactly 24 field elements in this layout:
+  `[root(8) | nonce_field_rep(8) | hash(leaf||nonce)(8)]`.
 
 ## Notes
 
@@ -31,10 +32,12 @@ This example demonstrates how to use the generated C bindings to call the TFHE p
 - API returns status codes: `BATTERY_OK`, `BATTERY_ERR_NULL`, `BATTERY_ERR_BADLEN`, `BATTERY_ERR_SEEDLEN`, `BATTERY_ERR_INPUT`, `BATTERY_ERR_BUFSZ`.
 - All inputs/outputs use opaque byte buffers; no special alignment requirements.
 - For `zkp_generate_proof`:
-  - Hash width is `HASH_SIZE = 8` field elements. After commit 8bca163, the STARK trace starts with an extra first row hashing `(leaf || nonce)`, so the number of rows is `levels + 1`.
-    The prover stack requires the trace height to be a power of two, so callers must choose `levels = 2^k - 1` (e.g., 31 -> rows 32).
-  - `leaf8_u32` has 8 field elements as `uint32_t` (must be canonical for the KoalaBear field).
+  - Hash width is `HASH_SIZE = 8` field elements. The STARK trace starts with an extra first row hashing `(leaf || nonce)`; we then prepend the sibling with a fixed right-neighbor flag. Therefore, `rows = levels(parent→root) + 2` must be a power of two (e.g., for 32 rows use `levels = 30`).
+  - `secret16_u32` packs both leaves as canonical field reps.
   - `neighbors8_by_level_u32` has `levels * 8` field elements in row-major order; level `l` occupies indices `[l*8 .. l*8+8)`.
-  - `sides_bitflags[lvl]` indicates neighbor position: `0` = neighbor on the right (concat `[current || neighbor]`), `1` = neighbor on the left (concat `[neighbor || current]`). Only `0` or `1` are accepted; additionally, `sides[0]` MUST be `0` to enforce proof uniqueness.
+  - `sides_bitflags[lvl]` indicates neighbor position: `0` = right, `1` = left. Only `0` or `1` are accepted.
   - `nonce32` is a 32‑byte seed used in Fiat–Shamir; different nonces produce different proofs for the same inputs. The Merkle root in `public_values[0..8]` is independent of the nonce; however, `public_values[16..24] = hash(leaf||nonce)` changes per nonce and can be used as a per‑session device identity.
   - Caller must provide output buffers (`proof_out`, `ct_out`) large enough for postcard‑serialized outputs; if too small, the functions return `BATTERY_ERR_BUFSZ`.
+
+Optional helper:
+- `zkp_parent_from_secret(secret16_u32, parent8_u32_out)` computes `parent = Poseidon2(leaf || sibling)` so the device can verify the server-provided path begins at the expected node without revealing the leaves.

--- a/examples/e2e/e2e.c
+++ b/examples/e2e/e2e.c
@@ -52,15 +52,15 @@ static void print_end_stats(const char* op, const memsnap_t* before) {
 
 int main(int argc, char** argv) {
     const char* mode = (argc > 1) ? argv[1] : "both"; // modes: "zkp", "tfhe", "both"
-    // ZKP: generate public values (e.g., Merkle root)  and zk proof for a provided leaf & path
-    // Use a compile-time constant to avoid VLA warnings
-    // The ZKP trace adds an initial row for hash(leaf||nonce),
-    // so `levels + 1` must be a power of two. For a depth-32 demo, pass 31 here.
-    enum { LEVELS = 31 }; // demo depth -> rows = 32
-    uint32_t leaf8_u32[8];
+    // ZKP: device knows both leaves; server supplies parent→root path.
+    // rows = levels(parent→root) + 2 must be a power of two.
+    // For a depth-32 demo: parent→root levels = 30 -> rows = 32.
+    enum { LEVELS = 30 }; // parent→root
+    uint32_t secret16_u32[16]; // [leaf(8) | sibling(8)]
     uint32_t neighbors8_by_level_u32[LEVELS * 8];
     uint8_t sides[LEVELS];
-    for (int i = 0; i < 8; i++) leaf8_u32[i] = 4; // demo leaf values
+    for (int i = 0; i < 8; i++) secret16_u32[i] = 4;      // device leaf
+    for (int i = 0; i < 8; i++) secret16_u32[8 + i] = 3;  // sibling
     for (size_t l = 0; l < LEVELS; l++) {
         for (int j = 0; j < 8; j++) neighbors8_by_level_u32[l*8 + j] = 3; // demo neighbors
         sides[l] = 0; // 0 = right, non-zero = left; require sides[0] == 0
@@ -72,8 +72,7 @@ int main(int argc, char** argv) {
     printf("[info] Packing ZKP args...\n");
     unsigned char args_buf[1<<16];
     size_t args_len = 0;
-    int rc = zkp_pack_args(leaf8_u32,
-                           neighbors8_by_level_u32,
+    int rc = zkp_pack_args(neighbors8_by_level_u32,
                            sides,
                            LEVELS,
                            args_buf,
@@ -90,7 +89,8 @@ int main(int argc, char** argv) {
         unsigned char proof_buf[1<<19]; // 0.5 MiB demo buffer
         size_t proof_written = 0;
         // zkp_generate_proof returns a postcard-serialized bundle: (proof, public_values)
-        rc = zkp_generate_proof(args_buf,
+        rc = zkp_generate_proof(secret16_u32,
+                                args_buf,
                                 args_len,
                                 zkp_nonce,
                                 proof_buf,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,8 +3,10 @@ use crate::aes_ctr::aes_ctr_encrypt_in_place;
 use crate::poly::Poly;
 use crate::tfhe::encode_bits_as_trlwe_plaintext;
 use crate::tfhe::{TFHEPublicKey, TRLWECiphertext};
+use crate::zkp::HASH_SIZE;
 use crate::zkp::{self, MerkleInclusionProof, Val};
 
+use p3_field::PrimeField32;
 use p3_field::integers::QuotientMap;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
@@ -134,6 +136,43 @@ pub extern "C" fn tfhe_pk_encrypt(
     }
 }
 
+/// Compute the parent hash from the two secret leaves using the same Poseidon2 parameters
+/// and orientation used in the Merkle tree: parent = H(leaf || sibling) with selector=0.
+/// Inputs:
+/// - `secret16_u32`: two concatenated leaves as 16 u32 words.
+/// Outputs:
+/// - `parent8_u32_out`: 8 u32 words with the parent field elements.
+#[unsafe(no_mangle)]
+pub extern "C" fn zkp_parent_from_secret(
+    secret16_u32: *const u32,
+    parent8_u32_out: *mut u32,
+) -> i32 {
+    if secret16_u32.is_null() || parent8_u32_out.is_null() {
+        return BATTERY_ERR_NULL;
+    }
+    let words = unsafe { core::slice::from_raw_parts(secret16_u32, 16) };
+    let mut leaf = [Val::from_canonical_checked(0).unwrap(); 8];
+    let mut sib = [Val::from_canonical_checked(0).unwrap(); 8];
+    for i in 0..8 {
+        match Val::from_canonical_checked(words[i]) {
+            Some(v) => leaf[i] = v,
+            None => return BATTERY_ERR_INPUT,
+        }
+        match Val::from_canonical_checked(words[8 + i]) {
+            Some(v) => sib[i] = v,
+            None => return BATTERY_ERR_INPUT,
+        }
+    }
+
+    // Compute parent via reusable hashing logic
+    let parent = zkp::hash::parent_from_pair(&leaf, &sib);
+    let out = unsafe { core::slice::from_raw_parts_mut(parent8_u32_out, 8) };
+    for i in 0..8 {
+        out[i] = parent[i].as_canonical_u32();
+    }
+    BATTERY_OK
+}
+
 /// Encrypt bytes and return raw TRLWE ciphertext coefficients (no serialization).
 /// a_out and b_out must each point to arrays of length TFHE_TRLWE_N.
 #[unsafe(no_mangle)]
@@ -150,31 +189,38 @@ pub extern "C" fn tfhe_pk_encrypt_raw(
     if pk.is_null() || bytes.is_null() || seed32.is_null() || a_out.is_null() || b_out.is_null() {
         return BATTERY_ERR_NULL;
     }
+
     if seed_len != BATTERY_SEED_LEN {
         return BATTERY_ERR_SEEDLEN;
     }
+
     let bit_len = bytes_len.saturating_mul(8);
     if bit_len > TFHE_TRLWE_N {
         return BATTERY_ERR_BADLEN;
     }
+
     // Deserialize PK
     let pk_bytes = unsafe { core::slice::from_raw_parts(pk, pk_len) };
     let pk: TFHEPublicKey<TFHE_TRLWE_N, Q> = match postcard::from_bytes(pk_bytes) {
         Ok(v) => v,
         Err(_) => return BATTERY_ERR_INPUT,
     };
+
     // Build plaintext from bytes
     let data = unsafe { core::slice::from_raw_parts(bytes, bytes_len) };
     let pt_poly = encode_bits_as_trlwe_plaintext::<TFHE_TRLWE_N, Q>(data, bit_len);
+
     // RNG
     let seed = unsafe { core::slice::from_raw_parts(seed32, BATTERY_SEED_LEN) };
     let mut seed_arr = [0u8; BATTERY_SEED_LEN];
     seed_arr.copy_from_slice(seed);
     let mut rng = ChaCha20Rng::from_seed(seed_arr);
+
     // Encrypt
     let ct_obj = TRLWECiphertext::<TFHE_TRLWE_N, Q>::encrypt_with_public_key::<_, ERR_B>(
         &pt_poly, &pk, &mut rng,
     );
+
     // Write raw coefficients
     let a_dst = unsafe { core::slice::from_raw_parts_mut(a_out, TFHE_TRLWE_N) };
     let b_dst = unsafe { core::slice::from_raw_parts_mut(b_out, TFHE_TRLWE_N) };
@@ -193,14 +239,16 @@ struct ZkpProofBundle(
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct OpaqueMerklePathArgs {
-    leaf8_u32: [u32; 8],
+    // Parent-to-root siblings; the device supplies both leaves in `secret`.
     neighbors8_by_level_u32: Vec<[u32; 8]>,
     sides_bitflags: Vec<u8>,
 }
 
-/// Generate a Merkle-path ZK proof using a single opaque serialized argument, with a separate nonce.
+/// Generate a Merkle-path ZK proof. The device provides both secret leaves,
+/// and the opaque args contain the parent→root path supplied by the server.
 /// Inputs:
-/// - `args`/`args_len`: postcard-serialized OpaqueMerklePathArgs
+/// - `secret16_u32`: two concatenated leaves as 16 `u32` words: [leaf(8) | sibling(8)]
+/// - `args`/`args_len`: postcard-serialized OpaqueMerklePathArgs (parent→root)
 /// - `nonce32` (len=`BATTERY_NONCE_LEN`)
 /// Outputs:
 /// - `proof_out`/`proof_out_len`: caller-provided buffer for postcard-serialized bundle:
@@ -210,6 +258,7 @@ struct OpaqueMerklePathArgs {
 /// Serialization: postcard 1.x (stable).
 #[unsafe(no_mangle)]
 pub extern "C" fn zkp_generate_proof(
+    secret16_u32: *const u32,
     args: *const u8,
     args_len: usize,
     nonce32: *const u8,
@@ -217,7 +266,12 @@ pub extern "C" fn zkp_generate_proof(
     proof_out_len: usize,
     out_proof_written: *mut usize,
 ) -> i32 {
-    if args.is_null() || nonce32.is_null() || proof_out.is_null() || out_proof_written.is_null() {
+    if secret16_u32.is_null()
+        || args.is_null()
+        || nonce32.is_null()
+        || proof_out.is_null()
+        || out_proof_written.is_null()
+    {
         return BATTERY_ERR_NULL;
     }
     let args_bytes = unsafe { core::slice::from_raw_parts(args, args_len) };
@@ -225,27 +279,35 @@ pub extern "C" fn zkp_generate_proof(
         Ok(v) => v,
         Err(_) => return BATTERY_ERR_INPUT,
     };
-    let levels = args.neighbors8_by_level_u32.len();
-    if levels == 0 || args.sides_bitflags.len() != levels {
+    let levels_parent = args.neighbors8_by_level_u32.len();
+    if args.sides_bitflags.len() != levels_parent {
         return BATTERY_ERR_INPUT;
     }
-    // The ZKP trace includes an extra first row for hash(leaf||nonce),
-    // so the prover requires (levels + 1) to be a power of two.
-    let rows = levels + 1;
+    // rows = parent-levels + 2 (row0: hash(leaf||nonce), row1: hash(leaf||sibling)) must be power of two
+    let rows = levels_parent + 2;
     if !rows.is_power_of_two() {
         return BATTERY_ERR_INPUT;
     }
     let nonce = unsafe { core::slice::from_raw_parts(nonce32, BATTERY_NONCE_LEN) };
     let mut nonce_arr = [0u8; BATTERY_NONCE_LEN];
     nonce_arr.copy_from_slice(nonce);
+    // Parse secret: [leaf | sibling]
+    let secret_words = unsafe { core::slice::from_raw_parts(secret16_u32, 16) };
     let mut leaf = [Val::from_canonical_checked(0).unwrap(); 8];
+    let mut sibling = [Val::from_canonical_checked(0).unwrap(); 8];
     for i in 0..8 {
-        match Val::from_canonical_checked(args.leaf8_u32[i]) {
+        match Val::from_canonical_checked(secret_words[i]) {
             Some(v) => leaf[i] = v,
             None => return BATTERY_ERR_INPUT,
         }
+        match Val::from_canonical_checked(secret_words[8 + i]) {
+            Some(v) => sibling[i] = v,
+            None => return BATTERY_ERR_INPUT,
+        }
     }
-    let mut neighbors: Vec<([Val; 8], bool)> = Vec::with_capacity(levels);
+    let mut neighbors: Vec<([Val; 8], bool)> = Vec::with_capacity(levels_parent + 1);
+    // Prepend sibling at side=0 (right neighbor)
+    neighbors.push((sibling, false));
     for (lvl, neigh) in args.neighbors8_by_level_u32.iter().enumerate() {
         let mut arr = [Val::from_canonical_checked(0).unwrap(); 8];
         for j in 0..8 {
@@ -267,7 +329,7 @@ pub extern "C" fn zkp_generate_proof(
     let (proof, public_values) = zkp::generate_proof(&leaf, &neighbors, &nonce_arr);
     // Public values layout is fixed at 24 = 3 * HASH_SIZE elements:
     //   [root(8) | nonce_field(8) | hash(leaf||nonce)(8)].
-    if public_values.len() != 3 * zkp::HASH_SIZE {
+    if public_values.len() != 3 * HASH_SIZE {
         return BATTERY_ERR_INPUT;
     }
     let bundle = ZkpProofBundle(proof, public_values);
@@ -363,7 +425,6 @@ pub extern "C" fn tfhe_pack_public_key(
 /// Serialization: postcard 1.x (stable).
 #[unsafe(no_mangle)]
 pub extern "C" fn zkp_pack_args(
-    leaf8_u32: *const u32,
     neighbors8_by_level_u32: *const u32,
     sides_bitflags: *const u8,
     levels: usize,
@@ -371,20 +432,14 @@ pub extern "C" fn zkp_pack_args(
     out_len: usize,
     out_written: *mut usize,
 ) -> i32 {
-    if leaf8_u32.is_null()
-        || neighbors8_by_level_u32.is_null()
+    if neighbors8_by_level_u32.is_null()
         || sides_bitflags.is_null()
         || out.is_null()
         || out_written.is_null()
     {
         return BATTERY_ERR_NULL;
     }
-    if levels == 0 {
-        return BATTERY_ERR_INPUT;
-    }
-    let leaf_slice = unsafe { core::slice::from_raw_parts(leaf8_u32, 8) };
-    let mut leaf = [0u32; 8];
-    leaf.copy_from_slice(leaf_slice);
+    // levels may be 0 when the parent is the root
     let neigh_u32 = unsafe { core::slice::from_raw_parts(neighbors8_by_level_u32, levels * 8) };
     let sides = unsafe { core::slice::from_raw_parts(sides_bitflags, levels) };
     let mut neighbors: Vec<[u32; 8]> = Vec::with_capacity(levels);
@@ -396,7 +451,6 @@ pub extern "C" fn zkp_pack_args(
     }
     let sides_vec = sides.to_vec();
     let args = OpaqueMerklePathArgs {
-        leaf8_u32: leaf,
         neighbors8_by_level_u32: neighbors,
         sides_bitflags: sides_vec,
     };
@@ -475,15 +529,13 @@ mod tests {
     #[test]
     fn zkp_proof_buf_too_small() {
         // Pack args and then request proof with zero-sized buffer.
-        // Trace rows = levels + 1 must be a power of two.
-        let levels = 31usize; // rows = 32
-        let leaf = [4u32; 8];
+        // rows = levels(parent->root) + 2 must be a power of two.
+        let levels = 30usize; // rows = 32 after prepend
         let neighbors = vec![3u32; levels * 8];
         let sides = vec![0u8; levels];
         let mut args_buf = vec![0u8; 1 << 16];
         let mut args_len: usize = 0;
         let rc = zkp_pack_args(
-            leaf.as_ptr(),
             neighbors.as_ptr(),
             sides.as_ptr(),
             levels,
@@ -492,10 +544,22 @@ mod tests {
             &mut args_len as *mut usize,
         );
         assert_eq!(rc, BATTERY_OK);
+        // Secret = [leaf | sibling]
+        let secret: [u32; 16] = {
+            let mut s = [0u32; 16];
+            for i in 0..8 {
+                s[i] = 4;
+            }
+            for i in 0..8 {
+                s[8 + i] = 3;
+            }
+            s
+        };
         let nonce = [1u8; BATTERY_NONCE_LEN];
         let mut proof_written = 0usize;
         let mut dummy: u8 = 0;
         let rc2 = zkp_generate_proof(
+            secret.as_ptr(),
             args_buf.as_ptr(),
             args_len,
             nonce.as_ptr(),
@@ -509,15 +573,13 @@ mod tests {
 
     #[test]
     fn zkp_proof_bundle_roundtrip() {
-        // Build opaque args for a valid path (rows = levels + 1 = 32)
-        let levels = 31usize;
-        let leaf = [4u32; 8];
+        // Build opaque args for a valid path (parent->root). rows = levels + 2 = 32
+        let levels = 30usize;
         let neighbors = vec![3u32; levels * 8];
         let sides = vec![0u8; levels];
         let mut args_buf = vec![0u8; 1 << 16];
         let mut args_len: usize = 0;
         let rc = zkp_pack_args(
-            leaf.as_ptr(),
             neighbors.as_ptr(),
             sides.as_ptr(),
             levels,
@@ -528,10 +590,21 @@ mod tests {
         assert_eq!(rc, BATTERY_OK);
 
         // Generate the bundle and deserialize it
+        let secret: [u32; 16] = {
+            let mut s = [0u32; 16];
+            for i in 0..8 {
+                s[i] = 4;
+            }
+            for i in 0..8 {
+                s[8 + i] = 3;
+            }
+            s
+        };
         let nonce = [0x11u8; BATTERY_NONCE_LEN];
         let mut out = vec![0u8; 1 << 20];
         let mut written = 0usize;
         let rc2 = zkp_generate_proof(
+            secret.as_ptr(),
             args_buf.as_ptr(),
             args_len,
             nonce.as_ptr(),
@@ -544,10 +617,29 @@ mod tests {
 
         let bundle: ZkpProofBundle = postcard::from_bytes(&out[..written]).unwrap();
         // Expect exactly 3 * HASH_SIZE public values: root(8) | nonce_field(8) | hash(leaf||nonce)(8)
-        assert_eq!(bundle.1.len(), 3 * zkp::HASH_SIZE);
+        assert_eq!(bundle.1.len(), 3 * HASH_SIZE);
         // Re-serialize and deserialize again to check roundtrip stability of the bundle
         let bytes2 = postcard::to_allocvec(&bundle).unwrap();
         let bundle2: ZkpProofBundle = postcard::from_bytes(&bytes2).unwrap();
         assert_eq!(bundle2.1, bundle.1);
+    }
+
+    #[test]
+    fn parent_from_secret_shape() {
+        let secret: [u32; 16] = {
+            let mut s = [0u32; 16];
+            for i in 0..8 {
+                s[i] = 4;
+            }
+            for i in 0..8 {
+                s[8 + i] = 3;
+            }
+            s
+        };
+        let mut out = [0u32; 8];
+        let rc = zkp_parent_from_secret(secret.as_ptr(), out.as_mut_ptr());
+        assert_eq!(rc, BATTERY_OK);
+        // basic sanity: not all zeros (extremely unlikely), stays u32 domain
+        assert!(out.iter().any(|&x| x != 0));
     }
 }

--- a/src/zkp/hash.rs
+++ b/src/zkp/hash.rs
@@ -1,0 +1,70 @@
+use super::{HALF_FULL_ROUNDS, HASH_SIZE, PARTIAL_ROUNDS, Val, WIDTH, constants::RoundConstants};
+use p3_field::PrimeCharacteristicRing;
+use p3_field::integers::QuotientMap;
+use p3_koala_bear::GenericPoseidon2LinearLayersKoalaBear as PoseidonLayers;
+use p3_poseidon2::GenericPoseidon2LinearLayers;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+#[inline]
+fn permute_with_constants(
+    mut state: [Val; WIDTH],
+    constants: &RoundConstants<Val, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
+) -> [Val; WIDTH] {
+    // External linear layer before the first full rounds, matching AIR/generation.
+    PoseidonLayers::external_linear_layer(&mut state);
+
+    // Beginning full rounds.
+    for r in 0..HALF_FULL_ROUNDS {
+        for i in 0..WIDTH {
+            state[i] += constants.beginning_full_round_constants[r][i];
+            state[i] = state[i].cube();
+        }
+        PoseidonLayers::external_linear_layer(&mut state);
+    }
+
+    // Partial rounds.
+    for r in 0..PARTIAL_ROUNDS {
+        state[0] += constants.partial_round_constants[r];
+        state[0] = state[0].cube();
+        PoseidonLayers::internal_linear_layer(&mut state);
+    }
+
+    // Ending full rounds.
+    for r in 0..HALF_FULL_ROUNDS {
+        for i in 0..WIDTH {
+            state[i] += constants.ending_full_round_constants[r][i];
+            state[i] = state[i].cube();
+        }
+        PoseidonLayers::external_linear_layer(&mut state);
+    }
+    state
+}
+
+/// Poseidon2 two-to-one compression consistent with the Merkle node computation.
+/// Orientation is defined by argument order: state = [left || right].
+pub fn parent_from_pair(left: &[Val; HASH_SIZE], right: &[Val; HASH_SIZE]) -> [Val; HASH_SIZE] {
+    let mut state = [Val::from_canonical_checked(0).unwrap(); WIDTH];
+    state[..HASH_SIZE].copy_from_slice(left);
+    state[HASH_SIZE..2 * HASH_SIZE].copy_from_slice(right);
+    let mut rng = ChaCha20Rng::seed_from_u64(1);
+    let constants = RoundConstants::from_rng(&mut rng);
+    let out = permute_with_constants(state, &constants);
+    let mut digest = [Val::from_canonical_checked(0).unwrap(); HASH_SIZE];
+    digest.copy_from_slice(&out[..HASH_SIZE]);
+    digest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orientation_changes_output() {
+        let a = [Val::from_canonical_checked(1).unwrap(); HASH_SIZE];
+        let b = [Val::from_canonical_checked(2).unwrap(); HASH_SIZE];
+        let ab = parent_from_pair(&a, &b);
+        let ba = parent_from_pair(&b, &a);
+        assert_ne!(ab, ba);
+    }
+}

--- a/src/zkp/mod.rs
+++ b/src/zkp/mod.rs
@@ -422,4 +422,73 @@ mod test {
         let (_proof, public_values) = generate_proof(&leaf, &neighbors, &nonce);
         assert_eq!(&public_values[0..HASH_SIZE], &expected_root[..]);
     }
+
+    #[test]
+    fn row0_hash_equals_helper() {
+        use crate::zkp::hash::parent_from_pair;
+
+        let leaf = core::array::from_fn(|i| Val::from_canonical_checked((i as u32) + 1).unwrap());
+        let sibling = [Val::from_canonical_checked(2).unwrap(); 8];
+        let neighbors = [(sibling, false)]; // rows = 2 (power of two)
+        let nonce = [0xABu8; 32];
+        let (.., public_values) = generate_proof(&leaf, &neighbors, &nonce);
+        let nonce_field = nonce_field_rep(&nonce);
+        let expected_row0 = parent_from_pair(&leaf, &nonce_field);
+        assert_eq!(&public_values[2 * HASH_SIZE..3 * HASH_SIZE], &expected_row0);
+    }
+
+    #[test]
+    fn zero_level_path_parent_is_root() {
+        use crate::zkp::hash::parent_from_pair;
+        let leaf = [Val::from_canonical_checked(7).unwrap(); 8];
+        let sibling = [Val::from_canonical_checked(11).unwrap(); 8];
+        let neighbors = [(sibling, false)]; // parent is the root
+        let nonce = [3u8; 32];
+        let (_proof, public_values) = generate_proof(&leaf, &neighbors, &nonce);
+        let expected_root = parent_from_pair(&leaf, &sibling);
+        assert_eq!(&public_values[0..HASH_SIZE], &expected_root);
+        verify_proof(&nonce, &_proof, &public_values).expect("verify ok for rows=2");
+    }
+
+    #[test]
+    fn orientation_strictness_changes_root() {
+        // Build two paths with the same neighbor values but opposite side flags.
+        let leaf = [Val::from_canonical_checked(4).unwrap(); 8];
+        let sibling = [Val::from_canonical_checked(3).unwrap(); 8];
+        let levels_above_parent = 30usize; // rows = 32
+
+        let mut neighbors_a: Vec<([Val; 8], bool)> = Vec::with_capacity(levels_above_parent + 1);
+        neighbors_a.push((sibling, false));
+        for i in 0..levels_above_parent {
+            let is_left = i % 2 == 0; // mix of left/right
+            let val = if is_left { 5 } else { 6 };
+            neighbors_a.push(([Val::from_canonical_checked(val).unwrap(); 8], is_left));
+        }
+        let mut neighbors_b = neighbors_a.clone();
+        for i in 1..neighbors_b.len() {
+            neighbors_b[i].1 = !neighbors_b[i].1; // flip sides
+        }
+        let nonce = [0x55u8; 32];
+        let (_proof_a, pv_a) = generate_proof(&leaf, &neighbors_a, &nonce);
+        let (_proof_b, pv_b) = generate_proof(&leaf, &neighbors_b, &nonce);
+        assert_ne!(&pv_a[0..HASH_SIZE], &pv_b[0..HASH_SIZE]);
+    }
+
+    #[test]
+    fn single_step_air_matches_hash() {
+        use crate::zkp::hash::parent_from_pair;
+        use p3_matrix::Matrix;
+        // Prepare a single-step Merkle fold (rows=2)
+        let leaf = [Val::from_canonical_checked(8).unwrap(); 8];
+        let sibling = [Val::from_canonical_checked(9).unwrap(); 8];
+        let neighbors = [(sibling, false)];
+        let nonce = [0x77u8; 32];
+
+        let (_config, _air, trace, _pv) = build_fixture(&leaf, &neighbors, &nonce);
+        let expected = parent_from_pair(&leaf, &sibling);
+        let last_row = trace.row_slice(trace.height() - 1).unwrap();
+        let start = trace.width() - WIDTH;
+        let end = start + HASH_SIZE;
+        assert_eq!(&last_row[start..end], &expected);
+    }
 }

--- a/src/zkp/mod.rs
+++ b/src/zkp/mod.rs
@@ -21,6 +21,7 @@ use super::Vec;
 pub mod air;
 pub mod constants;
 pub mod generation;
+pub mod hash;
 
 pub const WIDTH: usize = 16;
 pub const HASH_SIZE: usize = 8;
@@ -392,56 +393,33 @@ mod test {
         verify_proof(&nonce, &proof, &public_values).expect("verify ok");
     }
 
-    // Not run by default. Run with: cargo test --release -- --ignored --nocapture
     #[test]
-    #[ignore]
-    fn bench_prove_timing_once() {
-        use std::time::Instant;
+    fn merkle_root_matches_hash_utils() {
+        use crate::zkp::hash::parent_from_pair;
+
+        // Build a path: parent = H(leaf || sibling), then 30 levels to root.
         let leaf = [Val::from_canonical_checked(4).unwrap(); 8];
-        let neighbors = [([Val::from_canonical_checked(3).unwrap(); 8], false); 31];
-        let nonce = [7u8; 32];
-
-        // Measure trace generation separately from proving.
-        let byte_hash = ByteHash {};
-        let u64_hash = U64Hash::new(KeccakF {});
-        let field_hash = FieldHash::new(u64_hash);
-        let compress = MyCompress::new(u64_hash);
-        let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(1);
-        let constants = RoundConstants::from_rng(&mut rng);
-        let val_mmcs = ValMmcs::new(field_hash, compress, rng);
-        let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
-        let challenger = Challenger::from_hasher(nonce.to_vec(), byte_hash);
-        let air = TestAir::new(constants);
-        let fri_params = create_benchmark_fri_params_zk(challenge_mmcs);
-        let dft = Dft::default();
-        let pcs = Pcs::new(
-            dft,
-            val_mmcs,
-            fri_params,
-            4,
-            rand_chacha::ChaCha20Rng::from_seed(nonce),
-        );
-        let config = MerkleInclusionConfig::new(pcs, challenger);
-
-        let nonce_field = nonce_field_rep(&nonce);
-        let t0 = Instant::now();
-        let trace = air.generate_trace_rows(&leaf, &neighbors, &nonce_field);
-        let gen_ms = t0.elapsed().as_secs_f64() * 1e3;
-        eprintln!("trace: rows={}, cols={}", trace.height(), trace.width());
-
-        let mut pv: Vec<Val> = Vec::with_capacity(3 * HASH_SIZE);
-        {
-            let last_row = trace.row_slice(trace.height() - 1).unwrap();
-            let start = trace.width() - WIDTH;
-            let end = start + HASH_SIZE;
-            pv.extend_from_slice(&last_row[start..end]);
-            pv.extend_from_slice(&nonce_field);
-            pv.extend_from_slice(&trace.values[start..end]);
+        let sibling = [Val::from_canonical_checked(3).unwrap(); 8];
+        let levels_above_parent = 30usize; // rows = 32 = neighbors.len() + 1
+        let mut neighbors: Vec<([Val; 8], bool)> = Vec::with_capacity(levels_above_parent + 1);
+        neighbors.push((sibling, false));
+        for i in 0..levels_above_parent {
+            let is_left = i % 2 == 0;
+            let val = if is_left { 5 } else { 6 };
+            neighbors.push(([Val::from_canonical_checked(val).unwrap(); 8], is_left));
         }
 
-        let t1 = Instant::now();
-        let _proof = prove(&config, &air, trace, &pv);
-        let prove_ms = t1.elapsed().as_secs_f64() * 1e3;
-        eprintln!("timing-ms: trace_gen={:.3} prove={:.3}", gen_ms, prove_ms);
+        // Compute expected root by folding with our hash utils.
+        let mut digest = parent_from_pair(&leaf, &sibling);
+        for i in 1..neighbors.len() {
+            let (ref n, is_left) = neighbors[i];
+            digest = if is_left { parent_from_pair(n, &digest) } else { parent_from_pair(&digest, n) };
+        }
+        let expected_root = digest;
+
+        // Prove and compare PV[0..HASH_SIZE] with expected root.
+        let nonce = [7u8; 32];
+        let (_proof, public_values) = generate_proof(&leaf, &neighbors, &nonce);
+        assert_eq!(&public_values[0..HASH_SIZE], &expected_root[..]);
     }
 }


### PR DESCRIPTION
- Devices hold a secret that corresponds to two sibling leafs of the merkle tree
- proof generation now receives the secret + the opaque merkle tree path returned by the server (/auth/witness endpoint)
- Added utils to compute the parent hash